### PR TITLE
Fix en Relaciones Alumno-Familiars

### DIFF
--- a/webpack/src/pages/home.vue
+++ b/webpack/src/pages/home.vue
@@ -73,20 +73,36 @@
 <script>
   import router from '../router'
 
-  export default{
-    created: function(){
+  export default {
+    data: ()=>({
+      personaUpdated:false
+    }),
+    created: function() {
       store.commit('updateTitle',"SIEP | Familiares");
     },
-    computed:{
+    mounted: function() {
+      
+    },
+    computed: {
       user(){
         return store.state.user
       },
       persona(){
+        console.log("tengo persona");
         return store.getters.persona;
-      },
+      }
+    },
+    watch:{
+      persona(value){
+        if(!this.personaUpdated){
+          this.createFamiliar(value);
+        }else{
+          console.log("Ya está actualizado");
+        }
+      }
     },
     methods:{
-      goToLogin:function(){
+      goToLogin: function(){
         router.push('/')
       },
       goToFamiliar:function(mode){
@@ -94,6 +110,24 @@
       },
       goToStudent:function(){
         router.push('/inscripciones')
+      },
+      createFamiliar: function(persona){
+        this.personaUpdated = true;
+        var pers = persona;
+        console.log("Holaaaaa",pers);
+        pers = _.omitBy(pers, _.isEmpty);
+        pers.vinculo
+        pers._method = "POST";
+        pers.familiar = 1;
+        pers.ciudad = pers.ciudad.nombre;
+        pers.alumno = 0;
+        if(pers.sexo === "Masculino"){
+          pers.vinculo = "Padre";
+        }else{
+          pers.vinculo = "Madre";
+        }
+        console.log("Cambiado",pers);
+        store.dispatch('apiCreatePersona',pers);
       }
     }
   }

--- a/webpack/src/pages/inscripciones/components/form_persona.vue
+++ b/webpack/src/pages/inscripciones/components/form_persona.vue
@@ -142,10 +142,8 @@
     <!-- Calle numero -->
     <v-text-field
             v-model="form.calle_nro"
-            :rules="inputRulesAlmostOne"
             label="Calle número"
             hint="Campo Requerido"
-            required
     ></v-text-field>
 
     <!-- Depto casa -->
@@ -246,7 +244,7 @@
           this.disabledOnUpdate = true;
           if(store.getters.persona) {
             this.form = store.getters.persona;
-            this.form.ciudad= this.form.ciudad.nombre;
+            this.form.ciudad = this.form.ciudad.nombre;
           }
         }
 

--- a/webpack/src/pages/inscripciones/home.vue
+++ b/webpack/src/pages/inscripciones/home.vue
@@ -54,7 +54,7 @@
       <!-- Resultados de Relaciones con Familiar -->
       <v-container fluid grid-list-md v-if="alumnos.length">
         <p >
-          Aquí debajo se listan los alumnos que están registrados como familiar suyo
+          AQUI DEBAJO SE LISTAN LOS ALUMNOS QUE ESTAN REGISTRADOS COMO FAMILIAR SUYO
         </p>
         <v-layout row wrap>
         <!-- <v-data-iterator
@@ -110,7 +110,7 @@
 
           <br>
           <p>
-            En caso de no obtener resultados de busqueda, puede registrar un alumno nuevo
+            EN CASO DE NO OBTENER RESULTADOS DE BUSQUEDA, PUEDE REGISTRAR UN ALUMNO NUEVO
           </p>
 
           <v-btn color="primary" @click="goNewStudent"><v-icon left>person_add</v-icon>Registrar Nuevo Alumno</v-btn>


### PR DESCRIPTION
Al intentar vincular un alumno a un familiar creado con anterioridad la vinculación falla si ese familiar no posee modelo Familiar.

Se arregla chequeando el modelo Familiar al loguearse a la PWA.